### PR TITLE
Add Font Awesome Icons

### DIFF
--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import './styles.css';
 import ProductReviews from './productReviews/productReviews.jsx';
-import ProductOverviewContainer from './productOverview/ProductOverviewContainer.jsx'
+import ProductOverviewContainer from './productOverview/ProductOverviewContainer.jsx';
+import './common/fontAwesomeIcons';
 
 class App extends React.Component {
   render() {

--- a/client/src/components/common/fontAwesomeIcons.js
+++ b/client/src/components/common/fontAwesomeIcons.js
@@ -1,0 +1,9 @@
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { far } from '@fortawesome/free-regular-svg-icons';
+import { faStar, faStarHalfAlt } from '@fortawesome/free-solid-svg-icons';
+
+library.add(
+  far,
+  faStar,
+  faStarHalfAlt,
+);

--- a/client/src/components/common/starRating.jsx
+++ b/client/src/components/common/starRating.jsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faStar } from '@fortawesome/free-regular-svg-icons';
-import { faStar as faSolidStar, faStarHalfAlt} from '@fortawesome/free-solid-svg-icons';
 import CSS from './starRating.module.css';
 
 const StarRating = () => {
   return (
     <div>
-      <FontAwesomeIcon icon={faSolidStar} className={CSS['star-rating']} />
-      <FontAwesomeIcon icon={faSolidStar} className={CSS['star-rating']} />
-      <FontAwesomeIcon icon={faSolidStar} className={CSS['star-rating']} />
-      <FontAwesomeIcon icon={faStarHalfAlt} className={CSS['star-rating']} />
-      <FontAwesomeIcon icon={faStar} className={CSS['star-rating']} />
+      <FontAwesomeIcon icon='star' className={CSS['star-rating']} />
+      <FontAwesomeIcon icon='star' className={CSS['star-rating']} />
+      <FontAwesomeIcon icon='star' className={CSS['star-rating']} />
+      <FontAwesomeIcon icon='star-half-alt' className={CSS['star-rating']} />
+      <FontAwesomeIcon icon={['far', 'star']} className={CSS['star-rating']} />
     </div>
   )
 }

--- a/client/src/components/common/starRating.jsx
+++ b/client/src/components/common/starRating.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar } from '@fortawesome/free-regular-svg-icons';
+import { faStar as faSolidStar, faStarHalfAlt} from '@fortawesome/free-solid-svg-icons';
+import CSS from './starRating.module.css';
+
+const StarRating = () => {
+  return (
+    <div>
+      <FontAwesomeIcon icon={faSolidStar} className={CSS['star-rating']} />
+      <FontAwesomeIcon icon={faSolidStar} className={CSS['star-rating']} />
+      <FontAwesomeIcon icon={faSolidStar} className={CSS['star-rating']} />
+      <FontAwesomeIcon icon={faStarHalfAlt} className={CSS['star-rating']} />
+      <FontAwesomeIcon icon={faStar} className={CSS['star-rating']} />
+    </div>
+  )
+}
+
+export default StarRating;

--- a/client/src/components/common/starRating.module.css
+++ b/client/src/components/common/starRating.module.css
@@ -1,0 +1,3 @@
+.star-rating {
+  color: #b1d2b0ff;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1358,6 +1358,51 @@
         }
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.15.tgz",
+      "integrity": "sha512-/HFHdcoLESxxMkqZAcZ6RXDJ69pVApwdwRos/B2kiMWxDSAX2dFK8Er2/+rG+RsrzWB/dsAyjefLmemgmfE18g==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
   },
   "homepage": "https://github.com/The-Chonky-Panda/Atelier#readme",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-brands-svg-icons": "^5.15.4",
+    "@fortawesome/free-regular-svg-icons": "^5.15.4",
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/react-fontawesome": "^0.1.15",
     "axios": "^0.21.4",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",


### PR DESCRIPTION
## Description
<!-- A short description for the purpose of this PR -->
This PR added [Font Awesome](https://fontawesome.com/) as our icon library, also added the skeleton for a reusable star rating component so that it can be used as a placeholder.

## How to test
<!-- How could this PR be tested? (e.g. unit tests, instructions for manual test) -->
The star rating component currently looks like this without any functionalities: 
<img width="100" alt="Screen Shot 2021-09-13 at 2 17 21 PM" src="https://user-images.githubusercontent.com/43324065/133144216-4c2fd437-8fad-4186-8061-726242afc27b.png">

To test other icons, search for the icon you want in [the icon library](https://fontawesome.com/v5.15/icons?d=gallery&p=2) first and get the class name for that icon. 
I didn't find an explicit class name table for these icons in React, but in general it follows the rule of `fa-`. For example, the html for the stars are `<i class="fas fa-star"></i>`, if it's `fas`, then it can be found in `@fortawesome/free-solid-svg-icons`; if it's `far`, then it can be found in `@fortawesome/free-regular-svg-icons`
Then you can `import { faStar } from '@fortawesome/free-regular-svg-icons'`

Resource: [Font Awesome with React](https://fontawesome.com/v5.15/how-to-use/on-the-web/using-with/react)
## Notes
<!-- Additional things reviewers should be aware of -->
I don't see a 'quarter star' in the icon library, so we may need to look into how to achieve that. But for now I think it's enough for the skeleton.

## Issue tracking
<!-- Link to Trello ticket -->
https://trello.com/c/5cJQm7nN