### PR TITLE
implement relatedProducts carousel skeleton

### DIFF
--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import './styles.css';
 import ProductReviews from './productReviews/productReviews.jsx';
+import RelatedProducts from './relatedProducts/RelatedProducts.jsx';
 import ProductOverviewContainer from './productOverview/ProductOverviewContainer.jsx';
 import './common/fontAwesomeIcons';
 
@@ -10,6 +11,7 @@ const App = () => (
   <div>
     <h1>Hello Atelier</h1>
     <ProductOverviewContainer />
+    <RelatedProducts />
     <ProductReviews />
   </div>
 );

--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -8,7 +8,7 @@ const ProductCard = (props) => {
   const productCategory = props.product.category.toUpperCase();
   return (
     <div className='card'>
-      <Button type={'outfit'} />
+      <Button type={ props.type } />
       <img src='' alt={ props.product.name } />
       <div className='container'>
         <p>{productCategory}</p>
@@ -27,6 +27,7 @@ ProductCard.propTypes = {
   name: PropTypes.string,
   category: PropTypes.string,
   default_price: PropTypes.number,
+  type: PropTypes.string,
 };
 
 export default ProductCard;

--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -1,23 +1,32 @@
 import React from 'react';
-import Button from './button.jsx';
+import PropTypes from 'prop-types';
+import Button from './Button.jsx';
+import StarRating from '../common/starRating.jsx';
 import './styles.css';
-// import star rating;
 
-const ProductCard = props => {
+const ProductCard = (props) => {
+  const productCategory = props.product.category.toUpperCase();
   return (
     <div className='card'>
       <Button type={'outfit'} />
-      <img src='' alt='' />
+      <img src='' alt={ props.product.name } />
       <div className='container'>
-        <p>product category</p>  {/* in caps */}
-        <p><b>product name</b></p>
+        <p>{productCategory}</p>
+        <p><b>{ props.product.name }</b></p>
         {/* 3. price for default style
           if on sale, sale price in red followed by orig. price w/ strikethrough */}
-        <p>product price</p>
-        {/* <p>star rating</p> import Tingjun's component? hide if no reviews */}
+        <p>{ props.product.default_price }</p>
+        <StarRating />
       </div>
     </div>
-  )
+  );
+};
+
+ProductCard.propTypes = {
+  product: PropTypes.object,
+  name: PropTypes.string,
+  category: PropTypes.string,
+  default_price: PropTypes.number,
 };
 
 export default ProductCard;

--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import ProductCard from './ProductCard.jsx';
+
+class RelatedProducts extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      relatedProducts: [],
+    };
+  }
+
+  // get product id from overview
+  componentDidMount() {
+    // make api call to related products
+    fetch('http://127.0.0.1:3000/relatedProducts') // get request to server route
+      .then((res) => res.json())
+      .then((data) => {
+        this.setState((prevState) => ({ ...prevState, relatedProducts: data }));
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  render() {
+    return (
+      <div>
+        <div>RELATED PRODUCTS</div>
+        {this.state.relatedProducts.map((product) => (<ProductCard type={'related'} key={product.id} product={product}/>))};
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({ currentProduct: state.currentProduct });
+
+export default connect(mapStateToProps)(RelatedProducts);

--- a/client/src/components/relatedProducts/styles.css
+++ b/client/src/components/relatedProducts/styles.css
@@ -7,6 +7,7 @@
 
 .card {
   /* Add shadows to create the "card" effect */
+  display: inline-block;
   box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
   transition: 0.3s;
   width: 15%;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "nodemon": "^2.0.12",
+    "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.5",

--- a/server/relatedProducts.js
+++ b/server/relatedProducts.js
@@ -1,0 +1,23 @@
+const axios = require('axios');
+require('dotenv').config();
+
+const productUrl = 'https://app-hrsei-api.herokuapp.com/api/fec2/hr-rpp/products/';
+// http://example.com/page?parameter=value&also=another
+// routes: /products /products/:product_id /products/:product_id/styles
+const apiKey = process.env.API_KEY;
+
+const getRelatedProducts = (id, callback) => {
+  axios.get(`${productUrl}${id}/related`, {
+    headers: { Authorization: apiKey },
+  })
+    .then((res) => {
+      callback(null, res.data);
+    })
+    .catch((err) => {
+      callback(err);
+    });
+};
+
+module.exports = {
+  getRelatedProducts,
+};

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ const path = require('path');
 const express = require('express'); // npm installed
 const { getProduct, getStyles } = require('./products'); // Atelier api call to get product/product styles data
 const { getReviews, getReviewMeta } = require('./reviews');
+const { getRelatedProducts } = require('./relatedProducts');
 
 const app = express();
 
@@ -47,4 +48,31 @@ app.get('/reviews', (req, res) => {
     });
 });
 
+app.get('/relatedProducts', (req, res) => {
+  const id = req.query.product_id || 47426;
+  getRelatedProducts(id, (err, data) => {
+    if (err) {
+      throw err;
+    } else {
+      // remove duplicate ids
+      const uniqueData = [...new Set(data)];
+      const response = uniqueData.map((productId) => {
+        console.log(productId);
+        return new Promise((resolve, reject) => {
+          getProduct(productId, (product) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(product);
+            }
+          });
+        });
+      });
+      Promise.all(response)
+        .then((products) => {
+          res.send(JSON.stringify(products));
+        });
+    }
+  });
+});
 app.listen(3000);


### PR DESCRIPTION
## Description
This is the carousel that renders the product cards for each product related to the product in the overview

## How to test
manually - should render product cards when loading the app.

## Notes
it requires multiple api calls, one to get the ids for related products, and then another call for each of these ids to get the product info, so it slows down the page loading quite a bit. I still have to do a styles api call to get the image links. Right now there's an alt tag for images.

## Issue tracking
https://trello.com/c/z4rkZ57B/83-m-create-related-products-component