### PR TITLE
fix merge conflicts

### DIFF
--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -1,6 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import Button from './Button.jsx';
 import StarRating from '../common/starRating.jsx';
 import './styles.css';
@@ -11,7 +10,7 @@ const ProductCard = (props) => {
 
   return (
     <div className='card'>
-      <Button type={ props.type } product={ product } onClickStar={ props.onClickStar } />
+      <Button type={ props.type } product={ props.product } onClickStar={ props.onClickStar } />
       <img src='' alt={ product.name } />
       <div className='container'>
         <p>{productCategory}</p>

--- a/server/products.js
+++ b/server/products.js
@@ -8,14 +8,13 @@ const url = 'https://app-hrsei-api.herokuapp.com/api/fec2/hr-rpp/products';
 const apiKey = process.env.API_KEY;
 
 const getProduct = (id, callback) => {
-  axios.get(`${url}/${id}?`, {
+  axios.get(`${url}/${id}`, {
     headers: { Authorization: apiKey },
   })
     .then((res) => {
       callback(res.data);
     })
     .catch((err) => {
-      console.log(err);
       throw err;
     });
 };


### PR DESCRIPTION
## Description
modal broke from merges this morning, just implemented a quick fix. (had to change Button props back to product = {props.product} instead of product = {product}.

## How to test
manually - after page loads, click star in related product card to open modal, and close button to close it.

## Notes
not sure why product = {product} doesn't work when it was defined earlier and the variable works for the rest of the code. will look into that when i have more time.

## Issue tracking
https://trello.com/c/mvj1Kal1/84-s-create-comparison-modal