### PR TITLE
add tests for rendering productCard and Outfit components

### DIFF
--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -53,7 +53,7 @@ class RelatedProducts extends React.Component {
   render() {
     return (
       <div>
-        <div data-testid='relatedProducts'>RELATED PRODUCTS</div>
+        <div>RELATED PRODUCTS</div>
         {this.state.relatedProducts.map((product) => <ProductCard type={'related'} key={product.product.id}
           product={product}
           onClickStar={ this.onClickStar }

--- a/client/src/components/relatedProducts/relatedProducts.test.js
+++ b/client/src/components/relatedProducts/relatedProducts.test.js
@@ -6,9 +6,10 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import fetchMock from 'jest-fetch-mock';
 import rootReducer from '../../reducers/rootReducer';
-import testReview from '../../fixtures/testReview.json';
 import testRelatedProducts from '../../fixtures/testRelatedProducts.json';
 import RelatedProducts from './RelatedProducts.jsx';
+import Outfit from './Outfit.jsx';
+import ProductCard from './ProductCard.jsx';
 
 describe('relatedProducts', () => {
   const testStore = createStore(
@@ -17,13 +18,37 @@ describe('relatedProducts', () => {
     applyMiddleware(thunk),
   );
 
-  it('should render without crashing', () => {
-    const { getByTestId } = render(
+  it('should render RelatedProducts component without crashing', () => {
+    const { getByText } = render(
       <Provider store={testStore}>
         <RelatedProducts />
       </Provider>,
     );
+    expect(getByText('RELATED PRODUCTS')).toBeTruthy();
+  });
 
-    expect(getByTestId('relatedProducts')).toBeTruthy();
+  const product = {
+    product: {
+      category: 'Accessories',
+      default_price: '69.00',
+      description: 'Where you\'re going you might not need roads, but you definitely need some shades. Give those baby blues a rest and let the future shine bright on these timeless lenses.',
+      id: 47422,
+      name: 'Bright Future Sunglasses',
+      slogan: 'You\'ve got to wear shades',
+    },
+  };
+
+  it('should render related product ProductCard component without crashing', () => {
+    const { getByText } = render(<ProductCard product={ product } />);
+    expect(getByText('Bright Future Sunglasses')).toBeTruthy();
+  });
+
+  it('should render Outfit component without crashing', () => {
+    const { getByText } = render(
+      <Provider store={testStore}>
+        <Outfit />
+      </Provider>,
+    );
+    expect(getByText('YOUR OUTFIT')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Description
Added tests for productCard and Outfit just so rendering of all main components in the related products widget are tested.

## How to test
run npm test

## Notes
This is just confirming that the components render. Props are manually passed in for the ProductCard. Still haven't figured out how to test dynamic rendering with state update, and will have to add tests for click events.

## Issue tracking
https://trello.com/c/Rrf5Czej/116-s-add-productcard-and-outfit-render-tests