### PR TITLE
updated productCard to render default image

### DIFF
--- a/client/src/components/relatedProducts/Button.jsx
+++ b/client/src/components/relatedProducts/Button.jsx
@@ -6,11 +6,11 @@ import './styles.css';
 const Button = (props) => {
   // if props = related product, render
   if (props.type === 'related') {
-    return <FontAwesomeIcon icon={['far', 'star']}
+    return <FontAwesomeIcon icon={['far', 'star']} className='icon'
       onClick={ () => props.onClickStar(props.product) } />;
   }
   // else if props = outfit, render
-  return <FontAwesomeIcon icon={['far', 'times-circle']}
+  return <FontAwesomeIcon icon={['far', 'times-circle']} className='icon'
     onClick={ () => props.onClickCircleX(props.product.id) }
   />;
 };

--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -5,17 +5,25 @@ import StarRating from '../common/starRating.jsx';
 import './styles.css';
 
 const ProductCard = (props) => {
-  const { product } = props.product;
+  const styles = props.product.styles.results;
+  let photo = '';
+  for (let i = 0; i < styles.length; i += 1) {
+    if (styles[i]['default?'] === true) {
+      photo = styles[i].photos[0].thumbnail_url;
+    }
+  }
   const { category, name } = props.product.product;
   return (
     <div className='card'>
-      <Button type={ props.type }
-        product={ props.product }
-        onClickStar={ props.onClickStar }
-        onClickCircleX={ props.onClickCircleX }
-      />
-      <img src='' alt={ product.name } />
-      <div className='container'>
+      <div className='image' style={{ backgroundImage: `url(${photo})`, size: 'cover', repeat: 'no-repeat' }}>
+        <Button type={ props.type }
+          product={ props.product }
+          onClickStar={ props.onClickStar }
+          onClickCircleX={ props.onClickCircleX }
+        />
+        {!photo ? props.product.product.name : ''}
+      </div>
+      <div>
         <p>{category.toUpperCase()}</p>
         <p><b>{name}</b></p>
         {/* 3. price for default style

--- a/client/src/components/relatedProducts/styles.css
+++ b/client/src/components/relatedProducts/styles.css
@@ -1,9 +1,8 @@
-/* remove default browser settings */
-/* * {
+div {
   margin: 0;
   padding: 0;
   border: 0;
-} */
+}
 
 .card {
   /* Add shadows to create the "card" effect */
@@ -11,6 +10,8 @@
   box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
   transition: 0.3s;
   width: 15%;
+  height: 60px;
+  margin: 0 2%;
 }
 
 /* On mouse-over, add a deeper shadow */
@@ -18,13 +19,12 @@
   box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
 }
 
-/* Add some padding inside the card container */
-.container {
-  padding: 2px 16px;
+.image {
+  height: 70px;
 }
 
-
 /* position button */
-.far {
-  margin: 10% 0 0 85%;
+.icon {
+  z-index: 1;
+  margin: 5% 0 0 85%;
 }


### PR DESCRIPTION
## Description
render image of related product on productCard

## How to test
manually - should see image when or alt message if no image available after page has loaded and related products carousel has rendered.

## Notes
CSS still needs work... (clearly).

## Issue tracking
https://trello.com/c/8xD6zaf1/122-s-update-image-on-product-cards