### PR TITLE
Pagination

### DIFF
--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -35,13 +35,13 @@ const ProductCard = (props) => {
       }
       if (styles[i].sale_price !== null) {
         price = (
-          <p>
+          <p className='cardInfo'>
             <span style={{ color: 'red' }}>${styles[i].sale_price}</span>
             <span style={{ textDecorationLine: 'line-through' }}>${relatedProduct.default_price}</span>
           </p>
         );
       } else {
-        price = <p><span>${relatedProduct.default_price}</span></p>;
+        price = <p className='cardInfo'><span>${relatedProduct.default_price}</span></p>;
       }
     }
   }
@@ -66,24 +66,22 @@ const ProductCard = (props) => {
     }
     if (styles[0].sale_price !== null) {
       price = (
-        <p>
+        <p className='cardInfo'>
           <span style={{ color: 'red' }}>${styles[0].sale_price}</span>
           <span style={{ textDecoration: 'strikethrough' }}>${relatedProduct.default_price}</span>
         </p>);
     } else {
-      price = <p><span>${relatedProduct.default_price}</span></p>;
+      price = <p className='cardInfo'><span>${relatedProduct.default_price}</span></p>;
     }
   }
 
   return (
     <div className='card'>
       { photo }
-      <div>
-        <p>{ category }</p>
-        <p><b>{ name }</b></p>
+      <p className='cardInfo'>{ category }</p>
+      <p className='cardInfo'><b>{ name }</b></p>
         { price }
         <StarRating />
-      </div>
     </div>
   );
 };

--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { faChevronRight, faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import ProductCard from './ProductCard.jsx';
 import Modal from './Modal.jsx';
@@ -60,15 +62,17 @@ class RelatedProducts extends React.Component {
     return (
       <div className='relatedProducts'>
         <div>RELATED PRODUCTS</div>
+        <FontAwesomeIcon className='arrow left' data-testid='left-arrow' icon={ faChevronLeft } />
         {this.state.relatedProducts.map((product) => <ProductCard type={'related'} key={product.product.id}
           product={ product }
           onClickStar={ this.onClickStar }
           />)
-      }
-      <Modal showModal= { this.state.showModal }
-        comparedProduct={ this.state.comparedProduct }
-        currentProduct={ this.props.currentProduct }
-        onClickCloseModal={ this.onClickCloseModal } />
+        }
+        <FontAwesomeIcon className='arrow right' data-testid='right-arrow' icon={ faChevronRight } />
+        <Modal showModal= { this.state.showModal }
+          comparedProduct={ this.state.comparedProduct }
+          currentProduct={ this.props.currentProduct }
+          onClickCloseModal={ this.onClickCloseModal } />
       </div>
     );
   }

--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -12,6 +12,7 @@ class RelatedProducts extends React.Component {
     this.state = {
       relatedProductIds: [],
       relatedProducts: [],
+      index: 0,
       showModal: false,
       comparedProduct: {
         product: {
@@ -22,6 +23,8 @@ class RelatedProducts extends React.Component {
         },
       },
     };
+    this.onClickLeft = this.onClickLeft.bind(this);
+    this.onClickRight = this.onClickRight.bind(this);
     this.onClickStar = this.onClickStar.bind(this);
     this.onClickCloseModal = this.onClickCloseModal.bind(this);
   }
@@ -45,6 +48,22 @@ class RelatedProducts extends React.Component {
       });
   }
 
+  onClickLeft() {
+    if (this.state.index > 0) {
+      this.setState({
+        index: this.state.index - 1,
+      });
+    }
+  }
+
+  onClickRight() {
+    if (this.state.index < this.state.relatedProducts.length - 4) {
+      this.setState({
+        index: this.state.index + 1,
+      });
+    }
+  }
+
   onClickStar(product) {
     this.setState((prevState) => ({
       ...prevState,
@@ -59,16 +78,23 @@ class RelatedProducts extends React.Component {
 
   // eslint-disable-next-line class-methods-use-this
   render() {
+    const { index } = this.state;
+    const endRangeLimit = this.state.relatedProducts.length - 4;
+    const productRange = this.state.relatedProducts.slice(index, index + 4);
     return (
       <div className='relatedProducts'>
         <div>RELATED PRODUCTS</div>
-        <FontAwesomeIcon className='arrow left' data-testid='left-arrow' icon={ faChevronLeft } />
-        {this.state.relatedProducts.map((product) => <ProductCard type={'related'} key={product.product.id}
+        { index ? <FontAwesomeIcon className='arrow left' data-testid='left-arrow'
+            icon={ faChevronLeft } onClick={this.onClickLeft}/> : ''
+        }
+        {productRange.map((product) => <ProductCard type={'related'} key={product.product.id}
           product={ product }
           onClickStar={ this.onClickStar }
           />)
         }
-        <FontAwesomeIcon className='arrow right' data-testid='right-arrow' icon={ faChevronRight } />
+        {index < endRangeLimit && <FontAwesomeIcon className='arrow right' data-testid='right-arrow'
+            icon={ faChevronRight } onClick={this.onClickRight} />
+        }
         <Modal showModal= { this.state.showModal }
           comparedProduct={ this.state.comparedProduct }
           currentProduct={ this.props.currentProduct }

--- a/client/src/components/relatedProducts/styles.css
+++ b/client/src/components/relatedProducts/styles.css
@@ -15,6 +15,8 @@ div {
 .card {
   /* Add shadows to create the "card" effect */
   display: inline-block;
+  position: relative;
+  z-index: -1;
   box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
   transition: 0.3s;
   width: 15%;
@@ -34,6 +36,21 @@ div {
 /* position button */
 .icon {
   margin: 5% 0 0 85%;
+}
+
+.arrow {
+  position: relative;
+  margin: 5% 0;
+  z-index: 1;
+}
+.left {
+  position: relative;
+  margin-left: 5%;
+}
+
+.right {
+  position: relative;
+  margin-right: 5%;
 }
 
 .modal {

--- a/client/src/components/relatedProducts/styles.css
+++ b/client/src/components/relatedProducts/styles.css
@@ -15,13 +15,11 @@ div {
 .card {
   /* Add shadows to create the "card" effect */
   display: inline-block;
-  position: relative;
-  z-index: -1;
   box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
   transition: 0.3s;
-  width: 15%;
-  height: 100px;
-  margin: 2% 2%;
+  width: 20%;
+  height: 30em;
+  margin: 1% 1%;
 }
 
 /* On mouse-over, add a deeper shadow */
@@ -30,7 +28,7 @@ div {
 }
 
 .image {
-  height: 70px;
+  height: 20em;
 }
 
 /* position button */
@@ -38,11 +36,16 @@ div {
   margin: 5% 0 0 85%;
 }
 
+.cardInfo {
+  padding-left: 2%;;
+}
+
 .arrow {
   position: relative;
-  margin: 5% 0;
+  margin: 17% 0;
   z-index: 1;
 }
+
 .left {
   position: relative;
   margin-left: 5%;

--- a/client/src/components/relatedProducts/test/relatedProducts.test.js
+++ b/client/src/components/relatedProducts/test/relatedProducts.test.js
@@ -7,8 +7,22 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import rootReducer from '../../../reducers/rootReducer';
 import RelatedProducts from '../RelatedProducts.jsx';
+import relatedProductsTestData from './relatedProductsTestData.json';
 
 describe('relatedProducts', () => {
+  beforeEach(() => {
+    fetchMock.mockIf('http://127.0.0.1:3000', (req) => {
+      if (req.url.endsWith('/relatedProducts')) {
+        return relatedProductsTestData;
+      }
+      return {};
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.resetMocks();
+  });
+
   const testStore = createStore(
     rootReducer,
     {},
@@ -23,4 +37,45 @@ describe('relatedProducts', () => {
     );
     expect(getByText('RELATED PRODUCTS')).toBeTruthy();
   });
+
+  it('should not render left arrow when first related product displayed is at index 0',
+    () => {
+      const { queryAllByTestId } = render(
+        <Provider store={testStore}>
+          <RelatedProducts />
+        </Provider>,
+      );
+      expect(queryAllByTestId('left-arrow')).toHaveLength(0);
+    });
+
+  // it('should render right arrow when first related product displayed is at index 0',
+  //   () => {
+  //     const { getByTestId } = render(
+  //       <Provider store={testStore}>
+  //         <RelatedProducts />
+  //       </Provider>,
+  //     );
+  //     expect(getByTestId('right-arrow')).toBeInTheDocument();
+  //   });
+
+  // it('should render left arrow when first related product displayed is at index 1',
+  //   () => {
+  //     const { getByTestId } = render(
+  //       <Provider store={testStore}>
+  //         <RelatedProducts />
+  //       </Provider>,
+  //     );
+  //     expect(getByTestId('left-arrow')).toBeTruthy();
+  //   });
+
+  // it('should not render right arrow when first related product displayed
+  // is at index array length - 4',
+  //   () => {
+  //     const { queryAllByTestId } = render(
+  //       <Provider store={testStore}>
+  //         <RelatedProducts />
+  //       </Provider>,
+  //     );
+  //     expect(queryAllByTestId('right-arrow')).toHaveLength(0);
+  //   });
 });

--- a/client/src/components/relatedProducts/test/relatedProductsTestData.json
+++ b/client/src/components/relatedProducts/test/relatedProductsTestData.json
@@ -1,0 +1,571 @@
+[
+  {
+    "product": {
+      "category": "test-cat",
+      "created_at": "2021-08-26T20:30:48.129Z",
+      "default_price": "89.00",
+      "description": "this is a fake description",
+      "features": [
+        {
+          "feature": "test feature",
+          "value": "test value"
+        },
+        {
+          "feature": "test feature 2",
+          "value": "test value 2"
+        }
+      ],
+      "id": 12345,
+      "name": "test 12345 name",
+      "slogan": "this is a fake slogan",
+      "updated_at": "2021-08-26T20:30:48.129Z"
+    },
+    "styles": {
+      "product_id": "12345",
+      "results": [
+        {
+          "default?": "true",
+          "name": "style1",
+          "original_price": "89.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            },
+            {
+              "thumbnail_url": "third-fake-thumbnail-url",
+              "url": "third-fake-url"
+            },
+            {
+              "thumbnail_url": "fourth-fake-thumbnail-url",
+              "url": "fourth-fake-url"
+            },
+            {
+              "thumbnail_url": "fifth-fake-thumbnail-url",
+              "url": "fifth-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67890"
+        },
+        {
+          "default?": "false",
+          "name": "style2",
+          "original_price": "67.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67891"
+        },
+        {
+          "default?": "false",
+          "name": "style3",
+          "original_price": "50.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67892"
+        }
+      ]
+    }
+  },
+  {
+    "product": {
+      "campus": "hr-rpp",
+      "category": "test-cat",
+      "created_at": "2021-08-26T20:30:48.129Z",
+      "default_price": "89.00",
+      "description": "this is a fake description",
+      "features": [
+        {
+          "feature": "test feature",
+          "value": "test value"
+        },
+        {
+          "feature": "test feature 2",
+          "value": "test value 2"
+        }
+      ],
+      "id": 12346,
+      "name": "test 12346 name",
+      "slogan": "this is a fake slogan",
+      "updated_at": "2021-08-26T20:30:48.129Z"
+    },
+    "styles": {
+      "product_id": "12346",
+      "results": [
+        {
+          "default?": "true",
+          "name": "style1",
+          "original_price": "89.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67890"
+        },
+        {
+          "default?": "false",
+          "name": "style2",
+          "original_price": "67.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67891"
+        }
+      ]
+    }
+  },
+  {
+    "product": {
+      "campus": "hr-rpp",
+      "category": "test-cat",
+      "created_at": "2021-08-26T20:30:48.129Z",
+      "default_price": "89.00",
+      "description": "this is a fake description",
+      "features": [
+        {
+          "feature": "test feature",
+          "value": "test value"
+        },
+        {
+          "feature": "test feature 2",
+          "value": "test value 2"
+        }
+      ],
+      "id": 12347,
+      "name": "test 12347 name",
+      "slogan": "this is a fake slogan",
+      "updated_at": "2021-08-26T20:30:48.129Z"
+    },
+    "styles": {
+      "product_id": "12347",
+      "results": [
+        {
+          "default?": "true",
+          "name": "style1",
+          "original_price": "89.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67890"
+        },
+        {
+          "default?": "false",
+          "name": "style2",
+          "original_price": "67.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67891"
+        }
+      ]
+    }
+  },
+  {
+    "product": {
+      "campus": "hr-rpp",
+      "category": "test-cat",
+      "created_at": "2021-08-26T20:30:48.129Z",
+      "default_price": "89.00",
+      "description": "this is a fake description",
+      "features": [
+        {
+          "feature": "test feature",
+          "value": "test value"
+        },
+        {
+          "feature": "test feature 2",
+          "value": "test value 2"
+        }
+      ],
+      "id": 12348,
+      "name": "test 12348 name",
+      "slogan": "this is a fake slogan",
+      "updated_at": "2021-08-26T20:30:48.129Z"
+    },
+    "styles": {
+      "product_id": "12348",
+      "results": [
+        {
+          "default?": "true",
+          "name": "style1",
+          "original_price": "89.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            },
+            {
+              "thumbnail_url": "third-fake-thumbnail-url",
+              "url": "third-fake-url"
+            },
+            {
+              "thumbnail_url": "fourth-fake-thumbnail-url",
+              "url": "fourth-fake-url"
+            },
+            {
+              "thumbnail_url": "fifth-fake-thumbnail-url",
+              "url": "fifth-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67890"
+        },
+        {
+          "default?": "false",
+          "name": "style2",
+          "original_price": "67.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67891"
+        },
+        {
+          "default?": "false",
+          "name": "style3",
+          "original_price": "50.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67892"
+        }
+      ]
+    }
+  },
+  {
+    "product": {
+      "campus": "hr-rpp",
+      "category": "test-cat",
+      "created_at": "2021-08-26T20:30:48.129Z",
+      "default_price": "89.00",
+      "description": "this is a fake description",
+      "features": [
+        {
+          "feature": "test feature",
+          "value": "test value"
+        },
+        {
+          "feature": "test feature 2",
+          "value": "test value 2"
+        }
+      ],
+      "id": 12349,
+      "name": "test 12349 name",
+      "slogan": "this is a fake slogan",
+      "updated_at": "2021-08-26T20:30:48.129Z"
+    },
+    "styles": {
+      "product_id": "12349",
+      "results": [
+        {
+          "default?": "true",
+          "name": "style1",
+          "original_price": "89.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67890"
+        },
+        {
+          "default?": "false",
+          "name": "style2",
+          "original_price": "67.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67891"
+        }
+      ]
+    }
+  },
+  {
+    "product": {
+      "campus": "hr-rpp",
+      "category": "test-cat",
+      "created_at": "2021-08-26T20:30:48.129Z",
+      "default_price": "89.00",
+      "description": "this is a fake description",
+      "features": [
+        {
+          "feature": "test feature",
+          "value": "test value"
+        },
+        {
+          "feature": "test feature 2",
+          "value": "test value 2"
+        }
+      ],
+      "id": 12350,
+      "name": "test 12350 name",
+      "slogan": "this is a fake slogan",
+      "updated_at": "2021-08-26T20:30:48.129Z"
+    },
+    "styles": {
+      "product_id": "12350",
+      "results": [
+        {
+          "default?": "true",
+          "name": "style1",
+          "original_price": "89.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67890"
+        },
+        {
+          "default?": "false",
+          "name": "style2",
+          "original_price": "67.00",
+          "photos": [
+            {
+              "thumbnail_url": "fake-thumbnail-url",
+              "url": "fake-url"
+            },
+            {
+              "thumbnail_url": "another-fake-thumbnail-url",
+              "url": "another-fake-url"
+            }
+          ],
+          "sale_price": null,
+          "skus": {
+            "1": {
+              "quantity": 14,
+              "size": "7"
+            },
+            "2": {
+              "quantity": 2,
+              "size": "8.5"
+            }
+          },
+          "style_id": "67891"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Description
Display related products product cards 4 at a time. When starting from index 0, the left arrow will not render. If there are no additional products, the right arrow will not render. Otherwise, clicking left or right will move the index over by 1 card.

## How to test
Manually... sort of (please see notes). The arrows are conditionally rendered based on the length of the array of related products, which is saved in state. So, once again, I am having a heck of a time writing tests.

## Notes
right now there are only 4 related product cards based on our current product, so I can't confirm that it's all working as intended.

## Issue tracking
https://trello.com/c/kDpEaY9J/97-s-add-carousel-arrows
https://trello.com/c/DuI6V9ZG/115-m-add-pagination-to-related-products-carousel