### PR TITLE
implement history.push to reroute without page refresh

### DIFF
--- a/client/src/components/Wrapper.jsx
+++ b/client/src/components/Wrapper.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { withRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import ProductReviews from './productReviews/productReviews.jsx';
+import RelatedProducts from './relatedProducts/RelatedProducts.jsx';
+import Outfit from './relatedProducts/Outfit.jsx';
+import OverviewContainer from './productOverview/OverviewContainer.jsx';
+
+const Wrapper = (props) => (
+  <>
+    <OverviewContainer />
+    <RelatedProducts history={ props.history } />
+    <Outfit history={ props.history } />
+    <ProductReviews />
+  </>
+);
+
+Wrapper.propTypes = {
+  history: PropTypes.object,
+};
+
+export default withRouter(Wrapper);

--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -9,23 +9,29 @@ import {
 import './common/fontAwesomeIcons';
 
 import Banner from './common/banner.jsx';
-import ProductReviews from './productReviews/productReviews.jsx';
-import RelatedProducts from './relatedProducts/RelatedProducts.jsx';
-import Outfit from './relatedProducts/Outfit.jsx';
-import OverviewContainer from './productOverview/OverviewContainer.jsx';
+import Wrapper from './Wrapper.jsx';
 
-const App = () => (
-  <Router>
-    <Banner />
-    <Switch>
-      <Route exact path='/product/:productId'>
-        <OverviewContainer />
-        <RelatedProducts />
-        <Outfit />
-        <ProductReviews />
-      </Route>
-    </Switch>
-  </Router>
-);
+class App extends React.Component {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <Router>
+        <Banner />
+        <Switch>
+          <Route exact={false} path='/product/:productId' component={Wrapper} {...this.props}>
+            {/* <OverviewContainer />
+            <RelatedProducts />
+            <Outfit />
+            <ProductReviews /> */}
+          </Route>
+        </Switch>
+      </Router>
+    );
+  }
+}
 
 export default App;

--- a/client/src/components/relatedProducts/Outfit.jsx
+++ b/client/src/components/relatedProducts/Outfit.jsx
@@ -12,10 +12,16 @@ class Outfit extends React.Component {
       outfitProducts: [],
       index: 0,
     };
+    this.onClickCard = this.onClickCard.bind(this);
     this.onClickPlus = this.onClickPlus.bind(this);
     this.onClickCircleX = this.onClickCircleX.bind(this);
     this.onClickLeft = this.onClickLeft.bind(this);
     this.onClickRight = this.onClickRight.bind(this);
+  }
+
+  onClickCard(id) {
+    console.log('id', id);
+    this.props.history.push(`/product/${id}`);
   }
 
   onClickPlus() {
@@ -91,6 +97,7 @@ class Outfit extends React.Component {
           <ProductCard type={'outfit'} key={product.product.id}
           product={product}
           onClickCircleX={ this.onClickCircleX }
+          onClickCard={ this.onClickCard }
           />))
         }
         {index < endRangeLimit && <FontAwesomeIcon className='arrow right' data-testid='right-arrow'
@@ -109,6 +116,7 @@ const mapStateToProps = (state) => ({
 Outfit.propTypes = {
   currentProduct: PropTypes.object,
   currentStyle: PropTypes.object,
+  history: PropTypes.object,
 };
 
 export default connect(mapStateToProps)(Outfit);

--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -5,7 +5,6 @@ import StarRating from '../common/starRating.jsx';
 import './styles.css';
 
 const ProductCard = (props) => {
-  console.log('ProductCard', props);
   const relatedProduct = props.product.product;
   const { name } = relatedProduct;
   const category = relatedProduct.category.toUpperCase();
@@ -108,7 +107,7 @@ const ProductCard = (props) => {
     }
   }
   return (
-    <div className='card'>
+    <div className='card' onClick={() => props.onClickCard(relatedProduct.id)}>
       { photo }
       <p className='cardInfo'>{ category }</p>
       <p className='cardInfo'><b>{ name }</b></p>
@@ -125,6 +124,7 @@ ProductCard.propTypes = {
   default_price: PropTypes.number,
   type: PropTypes.string,
   showModal: PropTypes.bool,
+  onClickCard: PropTypes.func,
   onClickStar: PropTypes.func,
   onClickCloseModal: PropTypes.func,
   onClickCircleX: PropTypes.func,

--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -23,6 +23,7 @@ class RelatedProducts extends React.Component {
         },
       },
     };
+    this.onClickCard = this.onClickCard.bind(this);
     this.onClickLeft = this.onClickLeft.bind(this);
     this.onClickRight = this.onClickRight.bind(this);
     this.onClickStar = this.onClickStar.bind(this);
@@ -31,7 +32,9 @@ class RelatedProducts extends React.Component {
 
   // get product id from overview
   componentDidMount() {
-    fetch('http://127.0.0.1:3000/relatedProducts')
+    const url = window.location.pathname.match(/^\/product\/(\d+)/);
+    const id = url[1];
+    fetch(`http://127.0.0.1:3000/relatedProducts/${id}`)
       .then((res) => res.json())
       .then((relatedProducts) => {
         this.setState((prevState) => ({
@@ -46,6 +49,11 @@ class RelatedProducts extends React.Component {
       .catch((err) => {
         throw err;
       });
+  }
+
+  onClickCard(id) {
+    console.log('id', id);
+    this.props.history.push(`/product/${id}`);
   }
 
   onClickLeft() {
@@ -90,6 +98,7 @@ class RelatedProducts extends React.Component {
         {productRange.map((product) => <ProductCard type={'related'} key={product.product.id}
           product={ product }
           onClickStar={ this.onClickStar }
+          onClickCard={ this.onClickCard }
           />)
         }
         {index < endRangeLimit && <FontAwesomeIcon className='arrow right' data-testid='right-arrow'
@@ -108,6 +117,7 @@ const mapStateToProps = (state) => ({ currentProduct: state.currentProduct });
 
 RelatedProducts.propTypes = {
   currentProduct: PropTypes.object,
+  history: PropTypes.object,
 };
 
 export default connect(mapStateToProps)(RelatedProducts);

--- a/server/server.js
+++ b/server/server.js
@@ -68,8 +68,8 @@ app.get('/reviews', (req, res) => {
     });
 });
 
-app.get('/relatedProducts', (req, res) => {
-  const id = req.query.product_id || 47421;
+app.get('/relatedProducts/:id', (req, res) => {
+  const id = req.params.id || 47421;
   getRelatedProducts(id, (err, data) => {
     if (err) {
       throw err;


### PR DESCRIPTION
## Description
When clicking on card, url should  re-route to display details for related product just clicked on without refreshing or reloading the page.

## How to test
manually - please click on a related product card, and then you should see the product id in the url and the details in the overview container.

## Notes
I modified the router setup in order to be able to utilize history.push. This has allowed rerouting without page refreshing. However, the page still refreshes when manually typing the product id into the url. 

Note also, that I will have to adjust the styling because while the button to open the modal still works, it should not also reroute.  

Please make sure that my reorganization (ie wrapping our widgets in a wrapper component does not affect your functionality. also, i tried using a HOC to wrap our components, but couldn't get it to work with multiple component all at once. It would require a deeper dive). Also, I think having everything wrapped might facilitate refactoring for optimization if we want to limit ourselves to one api call.

Last note is that this form of rerouting does not trigger components to "re-mount", so (at least for related products) I will have to find a way to trigger a fresh api call. This might be a good time to refactor to the one api call so all the data can cascade down.

## Issue tracking
https://trello.com/c/e4UwI2s2/130-m-update-related-products-to-utilize-react-router
https://trello.com/c/BeDC2Bgt/119-m-add-click-event-to-product-cards-to-route-to-detail-page-for-that-related-product