### PR TITLE
pagination and card styling

### DIFF
--- a/client/src/components/relatedProducts/Outfit.jsx
+++ b/client/src/components/relatedProducts/Outfit.jsx
@@ -71,7 +71,7 @@ class Outfit extends React.Component {
   }
 
   onClickRight() {
-    if (this.state.index < this.state.outfitProducts.length - 4) {
+    if (this.state.index < this.state.outfitProducts.length - 3) {
       this.setState({
         index: this.state.index + 1,
       });
@@ -81,8 +81,8 @@ class Outfit extends React.Component {
   // eslint-disable-next-line class-methods-use-this
   render() {
     const { index } = this.state;
-    const endRangeLimit = this.state.outfitProducts.length - 4;
-    const productRange = this.state.outfitProducts.slice(index, index + 4);
+    const endRangeLimit = this.state.outfitProducts.length - 3;
+    const productRange = this.state.outfitProducts.slice(index, index + 3);
     return (
       <div className='outfit'>
         <div>YOUR OUTFIT</div>


### PR DESCRIPTION
## Description
added pagination and card styling to outfit to be consistent with related products

## How to test
manually. you can only add a product to the outfit once. so, each time you add an outfit, you have to click on a related product to navigate to the detail page of another product, and keep adding until there are at least 4 cards. Then arrows will show up and you can click forward and back in the carousel.

## Notes
I have not been able to figure out why the add to outfit card jumps position when adding cards. I have made a ticket for that bug. For now, trying to focus on functionality.

## Issue tracking
https://trello.com/c/MdRFWO3L/131-m-add-pagination-and-styling-to-outfit