### PR TITLE
fetch new related products after history.push redirects to new detail…

### DIFF
--- a/client/src/components/relatedProducts/Button.jsx
+++ b/client/src/components/relatedProducts/Button.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import './styles.css';
 
 const Button = (props) => {
+  console.log('button', props);
   // if props = related product, render
   if (props.type === 'related') {
     return <FontAwesomeIcon icon={['far', 'star']} className='icon'

--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -17,7 +17,7 @@ const ProductCard = (props) => {
       if (styles[i]['default?'] === true) {
         defaultStyle = true;
         if (styles[i].photos[0].thumbnail_url !== null) {
-          photo = <div className='image' style={{ backgroundImage: `url(${styles[i].photos[0].thumbnail_url})`, size: 'cover', repeat: 'no-repeat' }}>
+          photo = <div className='image' style={{ backgroundImage: `url(${styles[i].photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}>
               <Button type={ props.type }
                 product={ props.product }
                 onClickStar={ props.onClickStar }
@@ -48,7 +48,7 @@ const ProductCard = (props) => {
     }
     if (defaultStyle === false) {
       if (styles[0].photos[0].thumbnail_url !== null) {
-        photo = <div className='image' style={{ backgroundImage: `url(${styles[0].photos[0].thumbnail_url})`, size: 'cover', repeat: 'no-repeat' }}>
+        photo = <div className='image' style={{ backgroundImage: `url(${styles[0].photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}>
             <Button type={ props.type }
               product={ props.product }
               onClickStar={ props.onClickStar }
@@ -79,7 +79,7 @@ const ProductCard = (props) => {
     // photo
     const { styles } = props.product;
     if (styles.photos[0].thumbnail_url !== null) {
-      photo = <div className='image' style={{ backgroundImage: `url(${styles.photos[0].thumbnail_url})`, size: 'cover', repeat: 'no-repeat' }}>
+      photo = <div className='image' style={{ backgroundImage: `url(${styles.photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}>
           <Button type={ props.type }
             product={ props.product }
             onClickCircleX = { props.onClickCircleX }

--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -5,6 +5,7 @@ import StarRating from '../common/starRating.jsx';
 import './styles.css';
 
 const ProductCard = (props) => {
+  console.log('star', props);
   const relatedProduct = props.product.product;
   const { name } = relatedProduct;
   const category = relatedProduct.category.toUpperCase();
@@ -17,20 +18,9 @@ const ProductCard = (props) => {
       if (styles[i]['default?'] === true) {
         defaultStyle = true;
         if (styles[i].photos[0].thumbnail_url !== null) {
-          photo = <div className='image' style={{ backgroundImage: `url(${styles[i].photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}>
-              <Button type={ props.type }
-                product={ props.product }
-                onClickStar={ props.onClickStar }
-                onClickCircleX={ props.onClickCircleX }
-              />
-            </div>;
+          photo = <div className='image' style={{ backgroundImage: `url(${styles[i].photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}></div>;
         } else {
           photo = <div className='image'>
-            <Button type={ props.type }
-                product={ props.product }
-                onClickStar={ props.onClickStar }
-                onClickCircleX={ props.onClickCircleX }
-              />
             { name }
           </div>;
         }
@@ -48,20 +38,9 @@ const ProductCard = (props) => {
     }
     if (defaultStyle === false) {
       if (styles[0].photos[0].thumbnail_url !== null) {
-        photo = <div className='image' style={{ backgroundImage: `url(${styles[0].photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}>
-            <Button type={ props.type }
-              product={ props.product }
-              onClickStar={ props.onClickStar }
-              onClickCircleX={ props.onClickCircleX }
-            />
-          </div>;
+        photo = <div className='image' style={{ backgroundImage: `url(${styles[0].photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}></div>;
       } else {
         photo = <div className='image'>
-            <Button type={ props.type }
-                product={ props.product }
-                onClickStar={ props.onClickStar }
-                onClickCircleX={ props.onClickCircleX }
-              />
             { name }
           </div>;
       }
@@ -79,18 +58,9 @@ const ProductCard = (props) => {
     // photo
     const { styles } = props.product;
     if (styles.photos[0].thumbnail_url !== null) {
-      photo = <div className='image' style={{ backgroundImage: `url(${styles.photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}>
-          <Button type={ props.type }
-            product={ props.product }
-            onClickCircleX = { props.onClickCircleX }
-          />
-        </div>;
+      photo = <div className='image' style={{ backgroundImage: `url(${styles.photos[0].thumbnail_url})`, backgroundSize: 'cover', repeat: 'no-repeat' }}></div>;
     } else {
       photo = <div className='image'>
-          <Button type={ props.type }
-            product={ props.product }
-            onClickCircleX={ props.onClickCircleX }
-          />
           { name }
         </div>;
     }
@@ -107,12 +77,23 @@ const ProductCard = (props) => {
     }
   }
   return (
-    <div className='card' onClick={() => props.onClickCard(relatedProduct.id)}>
-      { photo }
-      <p className='cardInfo'>{ category }</p>
-      <p className='cardInfo'><b>{ name }</b></p>
-        { price }
-        <StarRating />
+    <div>
+      { props.type === 'related' ? <Button type={ props.type }
+        product={ props.product }
+        onClickStar={ props.onClickStar }
+        onClickCircleX={ props.onClickCircleX }
+        /> : <Button type={ props.type }
+        product={ props.product }
+        onClickCircleX={ props.onClickCircleX }
+        />
+      }
+      <div className='card' onClick={() => props.onClickCard(relatedProduct.id)}>
+        { photo }
+        <p className='cardInfo'>{ category }</p>
+        <p className='cardInfo'><b>{ name }</b></p>
+          { price }
+          <StarRating />
+      </div>
     </div>
   );
 };

--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -23,6 +23,7 @@ class RelatedProducts extends React.Component {
         },
       },
     };
+    this.fetchRelatedProducts = this.fetchRelatedProducts.bind(this);
     this.onClickCard = this.onClickCard.bind(this);
     this.onClickLeft = this.onClickLeft.bind(this);
     this.onClickRight = this.onClickRight.bind(this);
@@ -34,6 +35,10 @@ class RelatedProducts extends React.Component {
   componentDidMount() {
     const url = window.location.pathname.match(/^\/product\/(\d+)/);
     const id = url[1];
+    this.fetchRelatedProducts(id);
+  }
+
+  fetchRelatedProducts(id) {
     fetch(`http://127.0.0.1:3000/relatedProducts/${id}`)
       .then((res) => res.json())
       .then((relatedProducts) => {
@@ -54,6 +59,7 @@ class RelatedProducts extends React.Component {
   onClickCard(id) {
     console.log('id', id);
     this.props.history.push(`/product/${id}`);
+    this.fetchRelatedProducts(id);
   }
 
   onClickLeft() {

--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -58,6 +58,9 @@ class RelatedProducts extends React.Component {
 
   onClickCard(id) {
     console.log('id', id);
+    this.setState({
+      showModal: false,
+    });
     this.props.history.push(`/product/${id}`);
     this.fetchRelatedProducts(id);
   }
@@ -96,7 +99,7 @@ class RelatedProducts extends React.Component {
     const endRangeLimit = this.state.relatedProducts.length - 4;
     const productRange = this.state.relatedProducts.slice(index, index + 4);
     return (
-      <div className='relatedProducts'>
+      <div className='relatedProducts carousel'>
         <div>RELATED PRODUCTS</div>
         { index ? <FontAwesomeIcon className='arrow left' data-testid='left-arrow'
             icon={ faChevronLeft } onClick={this.onClickLeft}/> : ''

--- a/client/src/components/relatedProducts/styles.css
+++ b/client/src/components/relatedProducts/styles.css
@@ -4,13 +4,18 @@ div {
   border: 0;
 }
 
-.relatedProducts {
+.carousel {
+  width: 100%;
+  margin: 10% 0;
+}
+
+/* .relatedProducts {
   margin-top: 10%;
 }
 
 .outfit {
   margin-top: 5%;
-}
+} */
 
 .card {
   /* Add shadows to create the "card" effect */
@@ -33,7 +38,11 @@ div {
 
 /* position button */
 .icon {
-  margin: 5% 0 0 85%;
+  /* margin: 5% 0; */
+  display: inline-block;
+  position: relative;
+  z-index: 100;
+  margin: 0 0 0 50%;
 }
 
 .cardInfo {

--- a/client/src/components/relatedProducts/test/relatedProducts.test.js
+++ b/client/src/components/relatedProducts/test/relatedProducts.test.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-unused-vars */
+import React from 'react';
+import { render } from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import rootReducer from '../../../reducers/rootReducer';
+import RelatedProducts from '../RelatedProducts.jsx';
+
+describe('relatedProducts', () => {
+  const testStore = createStore(
+    rootReducer,
+    {},
+    applyMiddleware(thunk),
+  );
+
+  it('should render RelatedProducts component without crashing', () => {
+    const { getByText } = render(
+      <Provider store={testStore}>
+        <RelatedProducts />
+      </Provider>,
+    );
+    expect(getByText('RELATED PRODUCTS')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
… page

## Description
after clicking related card, detail page is rerouted to provide overview of clicked product. related products carousel is now updating appropriately.

## How to test
manually. when clicking on related product card, page will reroute to overview for that product and related products carousel will update with relevant related products.

## Notes
my original relatedProducts test file disappeared somewhere, so it's back in.
fixed the bug where clicking the star to show the modal was also causing the page to reroute, and then break because the modal couldn't update. However, now the styling has to be completely redone. Having trouble getting the star to overlap the cards.

## Issue tracking
https://trello.com/c/CYJU6PPK/138-update-related-products-when-overview-container-is-updated-with-historypush
https://trello.com/c/16BTwXau/133-m-adjust-styling-to-product-cards-so-clicking-button-icon-does-not-reroute-produce-overview-details