### PR TITLE
reviews change on url update

### DIFF
--- a/client/src/actions/fetchReviews.js
+++ b/client/src/actions/fetchReviews.js
@@ -2,7 +2,7 @@ import { changeReviews, changeLoadedReviews, changeRemainingReviews } from './pr
 import changeReviewMeta from './productReviews/changeReviewMeta';
 
 const fetchReviews = (productId) => (dispatch) => {
-  fetch(`http://127.0.0.1:3000/reviews?productId=${productId}`)
+  fetch(`http://127.0.0.1:3000/reviews/${productId}`)
     .then((response) => response.json())
     .then((response) => {
       dispatch(changeReviews(response.reviews));

--- a/client/src/components/Wrapper.jsx
+++ b/client/src/components/Wrapper.jsx
@@ -7,16 +7,18 @@ import Outfit from './relatedProducts/Outfit.jsx';
 import OverviewContainer from './productOverview/OverviewContainer.jsx';
 
 const Wrapper = (props) => (
-  <>
+  <div key={props.location.pathname}>
     <OverviewContainer />
     <RelatedProducts history={ props.history } />
     <Outfit history={ props.history } />
-    <ProductReviews />
-  </>
+    <ProductReviews productId={ props.match.params.productId } />
+  </div>
 );
 
 Wrapper.propTypes = {
   history: PropTypes.object,
+  location: PropTypes.object,
+  match: PropTypes.object,
 };
 
 export default withRouter(Wrapper);

--- a/client/src/components/productReviews/productReviews.jsx
+++ b/client/src/components/productReviews/productReviews.jsx
@@ -2,7 +2,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 
 import fetchReviews from '../../actions/fetchReviews';
 import { changeLoadedReviews, changeRemainingReviews } from '../../actions/productReviews/changeReviews';
@@ -24,8 +23,7 @@ class ProductReviews extends React.Component {
   }
 
   componentDidMount() {
-    const { match: { params: { productId } } } = this.props;
-    this.props.handleFetchReviews(productId);
+    this.props.handleFetchReviews(this.props.productId);
   }
 
   onLoadReviews() {
@@ -62,6 +60,7 @@ class ProductReviews extends React.Component {
 }
 
 const mapStateToProps = (state) => ({
+  currentProduct: state.currentProduct,
   reviews: state.reviews,
   loadedReviews: state.loadedReviews,
   remainingReviews: state.remainingReviews,
@@ -77,4 +76,4 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ProductReviews));
+export default connect(mapStateToProps, mapDispatchToProps)(ProductReviews);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.5",
-    "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
     "redux": "^4.1.1",
     "redux-thunk": "^2.3.0"

--- a/server/server.js
+++ b/server/server.js
@@ -45,8 +45,8 @@ app.get('/products/:id?', (req, res) => { // added optional id param to route
   });
 });
 
-app.get('/reviews', (req, res) => {
-  const id = req.query.productId || 47421;
+app.get('/reviews/:id', (req, res) => {
+  const id = req.params.id || 47421;
   const response = {};
   getReviews(id)
     .then((data) => {


### PR DESCRIPTION
## Description
<!-- A short description for the purpose of this PR -->
Got reviews to update with url update as well!
Added a `key` prop to `Wrapper`, according to answers in [StackOverflow](https://stackoverflow.com/questions/32261441/component-does-not-remount-when-route-parameters-change), `The idea is to change components key property when the URL changes and this forces React to re-mount the component.`

## How to test
<!-- How could this PR be tested? (e.g. unit tests, instructions for manual test) -->
Clicking on a product card and verify that reviews update.

## Notes
<!-- Additional things reviewers should be aware of -->

## Issue tracking
<!-- Link to Trello ticket -->
https://trello.com/c/S35aEBPc