### PR TITLE
wrap outfit and related products

### DIFF
--- a/client/src/components/Wrapper.jsx
+++ b/client/src/components/Wrapper.jsx
@@ -2,21 +2,18 @@ import React from 'react';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import RatingsAndReviews from './ratingsAndReviews/ratingsAndReviews.jsx';
-import RelatedProducts from './relatedProducts/RelatedProducts.jsx';
-import Outfit from './relatedProducts/Outfit.jsx';
+import RelatedProductsContainer from './relatedProducts/RelatedProductsContainer.jsx';
 import OverviewContainer from './productOverview/OverviewContainer.jsx';
 import withClickTracker from './withClickTracker.jsx';
 
 const OverviewContainerWithTracker = withClickTracker(OverviewContainer, 'product-overview');
-const RelatedProductsWithTracker = withClickTracker(RelatedProducts, 'related-products');
-const OutfitWithTracker = withClickTracker(Outfit, 'outfit');
+const RelatedProductsWithTracker = withClickTracker(RelatedProductsContainer, 'related-products');
 const RatingsAndReviewsWithTracker = withClickTracker(RatingsAndReviews, 'ratings-and-reviews');
 
 const Wrapper = (props) => (
   <div key={props.location.pathname}>
     <OverviewContainerWithTracker />
     <RelatedProductsWithTracker history={ props.history } />
-    <OutfitWithTracker history={ props.history } />
     <RatingsAndReviewsWithTracker productId={ props.match.params.productId } />
   </div>
 );

--- a/client/src/components/Wrapper.jsx
+++ b/client/src/components/Wrapper.jsx
@@ -9,13 +9,14 @@ import withClickTracker from './withClickTracker.jsx';
 
 const OverviewContainerWithTracker = withClickTracker(OverviewContainer, 'product-overview');
 const RelatedProductsWithTracker = withClickTracker(RelatedProducts, 'related-products');
+const OutfitWithTracker = withClickTracker(Outfit, 'outfit');
 const RatingsAndReviewsWithTracker = withClickTracker(RatingsAndReviews, 'ratings-and-reviews');
 
 const Wrapper = (props) => (
   <div key={props.location.pathname}>
     <OverviewContainerWithTracker />
     <RelatedProductsWithTracker history={ props.history } />
-    <Outfit history={ props.history } />
+    <OutfitWithTracker history={ props.history } />
     <RatingsAndReviewsWithTracker productId={ props.match.params.productId } />
   </div>
 );

--- a/client/src/components/relatedProducts/Button.jsx
+++ b/client/src/components/relatedProducts/Button.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import './styles.css';
 
 const Button = (props) => {
   console.log('button', props);

--- a/client/src/components/relatedProducts/ProductCard.jsx
+++ b/client/src/components/relatedProducts/ProductCard.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from './Button.jsx';
 import StarRating from '../common/starRating.jsx';
-import './styles.css';
 
 const ProductCard = (props) => {
   console.log('star', props);

--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -99,7 +99,7 @@ class RelatedProducts extends React.Component {
     const endRangeLimit = this.state.relatedProducts.length - 4;
     const productRange = this.state.relatedProducts.slice(index, index + 4);
     return (
-      <div className='relatedProducts carousel' id='related-products'>
+      <div className='relatedProducts carousel'>
         <div>RELATED PRODUCTS</div>
         { index ? <FontAwesomeIcon className='arrow left' data-testid='left-arrow'
             icon={ faChevronLeft } onClick={this.onClickLeft}/> : ''

--- a/client/src/components/relatedProducts/RelatedProductsContainer.jsx
+++ b/client/src/components/relatedProducts/RelatedProductsContainer.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import RelatedProducts from './RelatedProducts.jsx';
+import Outfit from './Outfit.jsx';
+
+const RelatedProductsContainer = (props) => (
+  <>
+    <RelatedProducts history={props.history} />
+    <Outfit history={props.history} />
+  </>
+);
+
+RelatedProductsContainer.propTypes = {
+  history: PropTypes.object,
+};
+
+export default RelatedProductsContainer;

--- a/client/src/components/relatedProducts/RelatedProductsContainer.jsx
+++ b/client/src/components/relatedProducts/RelatedProductsContainer.jsx
@@ -4,10 +4,10 @@ import RelatedProducts from './RelatedProducts.jsx';
 import Outfit from './Outfit.jsx';
 
 const RelatedProductsContainer = (props) => (
-  <>
+  <div id='related-products'>
     <RelatedProducts history={props.history} />
     <Outfit history={props.history} />
-  </>
+  </div>
 );
 
 RelatedProductsContainer.propTypes = {


### PR DESCRIPTION
## Description
Outfit component is part of the Related Products widget, so I wrapped Outfit and Related Products in a container, then wrapped that container with the click tracker. I also moved id='related-products' to the container. Tracker should now track both related products and outfit clicks as part of the related products widget.

## How to test
Click in widget. Terminal should log 201.

## Notes
Getting error in console about data leaking. I am creating a separate ticket for error handling, which I think will take care of that.

## Issue tracking
https://trello.com/c/Zdv5Htoi/146-s-combine-related-products-and-outfit-components-into-related-products-container-for-click-tracking
https://trello.com/c/GIKYFoBM/145-s-update-click-tracking-wrapper-to-related-products-widget-to-include-outfit