### PR TITLE
modify keys to trigger specific component remounts only on rerouting

### DIFF
--- a/client/src/components/Wrapper.jsx
+++ b/client/src/components/Wrapper.jsx
@@ -11,11 +11,12 @@ const RelatedProductsWithTracker = withClickTracker(RelatedProductsContainer, 'r
 const RatingsAndReviewsWithTracker = withClickTracker(RatingsAndReviews, 'ratings-and-reviews');
 
 const Wrapper = (props) => (
-  <div key={props.location.pathname}>
+  <div>
     <OverviewContainerWithTracker />
     <RelatedProductsWithTracker productId={ props.match.params.productId }
-      history={ props.history } />
-    <RatingsAndReviewsWithTracker productId={ props.match.params.productId } />
+      history={ props.history } location={props.location} />
+    <RatingsAndReviewsWithTracker key={props.location.pathname}
+      productId={ props.match.params.productId } />
   </div>
 );
 

--- a/client/src/components/relatedProducts/Outfit.jsx
+++ b/client/src/components/relatedProducts/Outfit.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { faChevronRight, faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import ProductCard from './ProductCard.jsx';
+import './styles.css';
 
 class Outfit extends React.Component {
   constructor(props) {

--- a/client/src/components/relatedProducts/RelatedProducts.jsx
+++ b/client/src/components/relatedProducts/RelatedProducts.jsx
@@ -50,7 +50,7 @@ class RelatedProducts extends React.Component {
         }));
       })
       .catch((err) => {
-        throw err;
+        console.log(err);
       });
   }
 
@@ -60,7 +60,7 @@ class RelatedProducts extends React.Component {
       showModal: false,
     });
     this.props.history.push(`/product/${id}`);
-    this.fetchRelatedProducts(id);
+    // this.fetchRelatedProducts(id);
   }
 
   onClickLeft() {

--- a/client/src/components/relatedProducts/RelatedProductsContainer.jsx
+++ b/client/src/components/relatedProducts/RelatedProductsContainer.jsx
@@ -6,7 +6,7 @@ import Outfit from './Outfit.jsx';
 const RelatedProductsContainer = (props) => (
   <div id='related-products' data-testid='related-products'>
     <RelatedProducts productId={props.productId} history={props.history}
-      key={props.location.pathname} />
+      key={props.productId} />
     <Outfit history={props.history} />
   </div>
 );

--- a/client/src/components/relatedProducts/RelatedProductsContainer.jsx
+++ b/client/src/components/relatedProducts/RelatedProductsContainer.jsx
@@ -5,7 +5,8 @@ import Outfit from './Outfit.jsx';
 
 const RelatedProductsContainer = (props) => (
   <div id='related-products' data-testid='related-products'>
-    <RelatedProducts productId={props.productId} history={props.history} />
+    <RelatedProducts productId={props.productId} history={props.history}
+      key={props.location.pathname} />
     <Outfit history={props.history} />
   </div>
 );
@@ -13,6 +14,7 @@ const RelatedProductsContainer = (props) => (
 RelatedProductsContainer.propTypes = {
   history: PropTypes.object,
   productId: PropTypes.string,
+  location: PropTypes.object,
 };
 
 export default RelatedProductsContainer;

--- a/client/src/components/relatedProducts/test/relatedProducts.test.js
+++ b/client/src/components/relatedProducts/test/relatedProducts.test.js
@@ -21,7 +21,7 @@ describe('relatedProducts', () => {
     };
     const { getByTestId } = render(
       <Provider store={testStore}>
-        <RelatedProductsContainer productId={47421} />
+        <RelatedProductsContainer productId='47421' />
       </Provider>,
     );
     expect(getByTestId('related-products')).toBeTruthy();

--- a/client/src/components/relatedProducts/test/relatedProducts.test.js
+++ b/client/src/components/relatedProducts/test/relatedProducts.test.js
@@ -16,9 +16,12 @@ describe('relatedProducts', () => {
   );
 
   it('should render RelatedProducts component without crashing', () => {
+    const location = {
+      pathname: 47421,
+    };
     const { getByTestId } = render(
       <Provider store={testStore}>
-        <RelatedProductsContainer productId={47421}/>
+        <RelatedProductsContainer productId={47421} />
       </Provider>,
     );
     expect(getByTestId('related-products')).toBeTruthy();


### PR DESCRIPTION
## Description
fix this error in console when clicking on related product product card:
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
removing api call from click handler to trigger history.push resolved error. 
also fixed persistance of outfit carousel on rerouting

## How to test
manually - open console. add outfit to list. click on related product. product in detail container should update. products in related products carousel should update. product in outfit carousel should still be there. ratings and reviews should update 
## Notes
On trying to fix API call to update related products after removal from of fetch from click handler, also noticed that outfit carousel was not persistent upon rerouting. Removed key from Wrapper, and added to individual components to trigger specific remounting.
also set key on related products component to allow for test to continue to pass.
note there are some duplicate results in the api, so please check around with a few items to see that everything really updates appropriately). note that there are no memory leak errors in console (there might be for duplicate keys because of the duplicate results from the api.

## Issue tracking
https://trello.com/c/laEzRTfT/151-s-fix-memory-leak-when-clicking-on-related-product-to-reroute
https://trello.com/c/YXND7YIE/152-s-fix-persistance-of-outfit-carousel-on-rerouting
