### PR TITLE
move modal display to related products section

### DIFF
--- a/client/src/components/relatedProducts/styles.css
+++ b/client/src/components/relatedProducts/styles.css
@@ -4,17 +4,20 @@ div {
   border: 0;
 }
 
+#related-products {
+  margin-top: 30vh;
+}
+
 .carousel {
   display: grid;
   grid-template-columns: 10vw 20vw 20vw 20vw 20vw 10vw;
   grid-template-rows: 1fr 1fr;
-  margin-top: 50vh;
-  max-height: 100vh;
+  margin-top: 10vh;
+  max-height: 90vh;
 }
 
 .carouselHeading {
   grid-column: 1 / span 2;
-  margin-bottom: 2vw;
 }
 
 .left {
@@ -28,6 +31,7 @@ div {
   grid-row-start: 2;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
+  margin-top: -20%;
 }
 
 .outfitCardContainer {
@@ -35,6 +39,7 @@ div {
   grid-row-start: 2;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
+  margin-top: -25%;
 }
 
 .right {
@@ -85,7 +90,7 @@ div {
   height: 30vh;
   grid-column: 2;
   grid-row: 2;
-  margin-top: -5%;
+  margin-top: -15%;
 }
 
 .modal {
@@ -93,7 +98,6 @@ div {
   z-index: 2;
   max-height: 50vh;
   overflow-y: auto;
-  top: 85%;
   margin: 0% 25%;
   background-color: whitesmoke;
   border: 1px solid black;


### PR DESCRIPTION
## Description
move modal display down to related products container

## How to test
manually - upon rendering of related product carousel, click on star icon in one of the product cards and modal will display in 

## Notes
might have to keep making adjustments to styling as widgets continue to be fleshed out and finalized.

## Issue tracking
https://trello.com/c/Hhv3Q4Hn/163-s-style-modal-to-appear-in-related-products-container