### PR TITLE
review body show more fix

### DIFF
--- a/client/src/components/ratingsAndReviews/reviews/review.jsx
+++ b/client/src/components/ratingsAndReviews/reviews/review.jsx
@@ -74,11 +74,12 @@ class Review extends React.Component {
         </div>
 
         <div className={CSS['review-body']}>
-          <div>{reviewBody}</div>
-          {!bodyShown
+          <div>{review.body.length > 250 ? reviewBody : review.body}
+          {review.body.length > 250 && !bodyShown
             && <div style={{
               fontStyle: 'italic', color: 'black', textDecoration: 'underline', cursor: 'pointer',
             }} onClick={this.loadBody}>Show More</div>}
+          </div>
         </div>
 
         {review.recommend


### PR DESCRIPTION
## Description
<!-- A short description for the purpose of this PR -->
Correct the 'show more' position and functionality.

## How to test
<!-- How could this PR be tested? (e.g. unit tests, instructions for manual test) -->
Navigate to a product with reviews that are longer than 250 characters (e.g. 47428, 47437)
Verify that for long reviews, 'show more' is displayed, and clicking on it shows the full text
<img width="785" alt="Screen Shot 2021-09-29 at 6 01 55 PM" src="https://user-images.githubusercontent.com/43324065/135360344-66bd4069-a49f-40d5-967c-964f61979376.png">
<img width="762" alt="Screen Shot 2021-09-29 at 6 02 01 PM" src="https://user-images.githubusercontent.com/43324065/135360359-0f2f4949-8647-4b92-8164-3872a2cfcb03.png">

Verify that for regular reviews,'show more' is not there
<img width="752" alt="Screen Shot 2021-09-29 at 6 02 14 PM" src="https://user-images.githubusercontent.com/43324065/135360385-b2bdb11a-17e6-4e0c-a01c-5d865ace59c1.png">

## Notes
<!-- Additional things reviewers should be aware of -->

## Issue tracking
<!-- Link to Trello ticket -->
https://trello.com/c/Cmm37r2i