### PR TITLE
filter duplicate ids for related products

### DIFF
--- a/server/relatedProducts.js
+++ b/server/relatedProducts.js
@@ -9,7 +9,8 @@ const getRelatedProducts = (id, callback) => {
     headers: { Authorization: apiKey },
   })
     .then((res) => {
-      callback(null, res.data);
+      const ids = [...new Set(res.data)];
+      callback(null, ids);
     })
     .catch((err) => {
       callback(err);


### PR DESCRIPTION
## Description
certain products have duplicate related products. e.g.. 47425 lists 47426 twice. results are now filtered so 47426 only appears in related products carousel once.

## How to test
manually - on separate branch navigate to product like 47425 which has duplicate related products. switch to this branch and navigate to same product. duplicates will not appear.

## Notes
filtering done on server side to optimize performance.

## Issue tracking
https://trello.com/c/uEx3QqhS/153-s-filter-api-results-to-avoid-duplicates