### PR TITLE
Filter bug fix

### DIFF
--- a/client/src/components/productOverview/Gallery/ThumbList.jsx
+++ b/client/src/components/productOverview/Gallery/ThumbList.jsx
@@ -6,6 +6,7 @@ const ThumbList = (props) => (
   <>
     <figure className='gallery-thumb-0' data-testid='gallery-thumb-0' onClick={() => props.handleImageClick(0)}>
       <img
+        data-testid='gallery-thumb-img-0'
         src={props.currentStyle.photos[props.thumb].thumbnail_url}
         className='gallery-thumb'
         alt='Thumbnail'>
@@ -16,6 +17,7 @@ const ThumbList = (props) => (
       props.currentStyle.photos[1] && <figure className='gallery-thumb-1' data-testid='gallery-thumb-1'
         onClick={() => props.handleImageClick(1)}>
         <img
+          data-testid='gallery-thumb-img-1'
           src={props.currentStyle.photos[props.thumb + 1].thumbnail_url}
           className='gallery-thumb'
           alt='Thumbnail'>
@@ -27,6 +29,7 @@ const ThumbList = (props) => (
       props.currentStyle.photos[2] && <figure className='gallery-thumb-2' data-testid='gallery-thumb-2'
         onClick={() => props.handleImageClick(2)}>
         <img
+          data-testid='gallery-thumb-img-2'
           src={props.currentStyle.photos[props.thumb + 2].thumbnail_url}
           className='gallery-thumb'
           alt='Thumbnail'>
@@ -38,6 +41,7 @@ const ThumbList = (props) => (
       props.currentStyle.photos[3] && <figure className='gallery-thumb-3' data-testid='gallery-thumb-3'
         onClick={() => props.handleImageClick(3)}>
         <img
+          data-testid='gallery-thumb-img-3'
           src={props.currentStyle.photos[props.thumb + 3].thumbnail_url}
           className='gallery-thumb'
           alt='Thumbnail'>
@@ -49,6 +53,7 @@ const ThumbList = (props) => (
       props.currentStyle.photos[4] && <figure className='gallery-thumb-4' data-testid='gallery-thumb-4'
         onClick={() => props.handleImageClick(4)}>
         <img
+          data-testid='gallery-thumb-img-4'
           src={props.currentStyle.photos[props.thumb + 4].thumbnail_url}
           className='gallery-thumb'
           alt='Thumbnail'>

--- a/client/src/components/productOverview/testingLibrary/AddToCart.test.js
+++ b/client/src/components/productOverview/testingLibrary/AddToCart.test.js
@@ -8,7 +8,7 @@ import fetchMock from 'jest-fetch-mock';
 import rootReducer from '../../../reducers/rootReducer';
 import testProduct from '../../../fixtures/testProduct.json';
 
-import AddToCart from '../AddToCart.jsx';
+import AddToCart from '../Cart/AddToCart.jsx';
 
 let testStore = null;
 

--- a/client/src/components/productOverview/testingLibrary/ImageGallery.test.js
+++ b/client/src/components/productOverview/testingLibrary/ImageGallery.test.js
@@ -8,7 +8,7 @@ import fetchMock from 'jest-fetch-mock';
 import rootReducer from '../../../reducers/rootReducer';
 import testProduct from '../../../fixtures/testProduct.json';
 
-import ImageGallery from '../ImageGallery.jsx';
+import ImageGallery from '../Gallery/ImageGallery.jsx';
 import '../../common/fontAwesomeIcons';
 
 let testStore = null;

--- a/client/src/components/productOverview/testingLibrary/ProductRating.test.js
+++ b/client/src/components/productOverview/testingLibrary/ProductRating.test.js
@@ -9,7 +9,7 @@ import rootReducer from '../../../reducers/rootReducer';
 import testProduct from '../../../fixtures/testProduct.json';
 import testReview from '../../../fixtures/testReview.json';
 
-import ProductInfo from '../ProductInfo.jsx';
+import ProductInfo from '../Info/ProductInfo.jsx';
 import '../../common/fontAwesomeIcons';
 
 let testStore = null;

--- a/client/src/components/productOverview/testingLibrary/ProductSummary.test.js
+++ b/client/src/components/productOverview/testingLibrary/ProductSummary.test.js
@@ -8,7 +8,7 @@ import fetchMock from 'jest-fetch-mock';
 import rootReducer from '../../../reducers/rootReducer';
 import testProduct from '../../../fixtures/testProduct.json';
 
-import ProductSummary from '../ProductSummary.jsx';
+import ProductSummary from '../Info/ProductSummary.jsx';
 
 let testStore = null;
 beforeAll(() => {

--- a/client/src/components/productOverview/testingLibrary/StyleList.test.js
+++ b/client/src/components/productOverview/testingLibrary/StyleList.test.js
@@ -8,7 +8,7 @@ import fetchMock from 'jest-fetch-mock';
 import rootReducer from '../../../reducers/rootReducer';
 import testProduct from '../../../fixtures/testProduct.json';
 
-import StyleList from '../StyleList.jsx';
+import StyleList from '../Info/StyleList.jsx';
 import '../../common/fontAwesomeIcons';
 
 let testStore = null;

--- a/client/src/components/ratingsAndReviews/reviews/sortingDropdown.jsx
+++ b/client/src/components/ratingsAndReviews/reviews/sortingDropdown.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import CSS from '../ratingsAndReviews.module.css';
-import { changeLoadedReviews, changeRemainingReviews } from '../../../actions/ratingsAndReviews/changeReviews';
+import { changeLoadedReviews, changeRemainingReviews, changeReviews } from '../../../actions/ratingsAndReviews/changeReviews';
 import { sortHelpful, sortNewest, sortRelevant } from '../../../helpers/sortReviews';
 
 class SortingDropdown extends React.Component {
@@ -29,7 +29,7 @@ class SortingDropdown extends React.Component {
     }
     const loadedReviews = reviews.slice(0, this.props.loadedReviews.length || 2);
     const remainingReviews = reviews.filter((review) => !loadedReviews.includes(review));
-    this.props.handleSortChange(loadedReviews, remainingReviews);
+    this.props.handleSortChange(loadedReviews, remainingReviews, reviews);
   }
 
   render() {
@@ -60,9 +60,10 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  handleSortChange: (loadedReviews, remainingReviews) => {
+  handleSortChange: (loadedReviews, remainingReviews, reviews) => {
     dispatch(changeLoadedReviews(loadedReviews));
     dispatch(changeRemainingReviews(remainingReviews));
+    dispatch(changeReviews(reviews));
   },
 });
 

--- a/client/src/components/relatedProducts/Modal.jsx
+++ b/client/src/components/relatedProducts/Modal.jsx
@@ -34,7 +34,7 @@ const Modal = (props) => {
   const rows = keys.map((key) => {
     if (features[key].currentProduct === true && features[key].comparedProduct === true) {
       return (
-        <tr className='features'>
+        <tr className='features' key={key}>
           <td className='check'>
             <FontAwesomeIcon data-testid='checkMark' icon={ faCheck } />
           </td>
@@ -45,7 +45,7 @@ const Modal = (props) => {
     // eslint-disable-next-line no-else-return
     } else if (features[key].comparedProduct === true) {
       return (
-        <tr className='features'>
+        <tr className='features' key={key}>
           <td className='check'>{ features[key].currentProduct }</td>
           <td>{key}</td>
           <td className='check'>
@@ -55,7 +55,7 @@ const Modal = (props) => {
       );
     } else if (features[key].currentProduct === true) {
       return (
-        <tr className='features'>
+        <tr className='features' key={key}>
           <td className='check'>
             <FontAwesomeIcon data-testid='checkMark' icon={ faCheck } />
           </td>
@@ -66,7 +66,7 @@ const Modal = (props) => {
     } else {
       return (
         // eslint-disable-next-line react/jsx-key
-        <tr className='features'>
+        <tr className='features' key={key}>
           <td className='check'>{features[key].currentProduct}</td>
           <td>{key}</td>
           <td className='check'>{features[key].comparedProduct}</td>


### PR DESCRIPTION
## Description
<!-- A short description for the purpose of this PR -->
When clicking on a star rating breakdown bar, the reviews list should be filtered based on that star rating, and after remove that filter, the reviews list should be displayed in the order of the selection from the sorting dropdown previous to any filtering.

## How to test
<!-- How could this PR be tested? (e.g. unit tests, instructions for manual test) -->
Manually - I used product 47432. Sort the reviews list based on any of the option, verify that reviews list changes, and filter the reviews by clicking on the star rating breakdown, verify that reviews are filtered, then remove the filters, and verify that the reviews are still displayed in the sorted order.

## Notes
<!-- Additional things reviewers should be aware of -->
Noticed some tests are failing, so also took care of those.
## Issue tracking
<!-- Link to Trello ticket -->
https://trello.com/c/A5nlMh14