### PR TITLE
fix spacing for relatedProducts headings

### DIFF
--- a/client/src/components/relatedProducts/styles.css
+++ b/client/src/components/relatedProducts/styles.css
@@ -7,8 +7,8 @@ div {
 .carousel {
   display: grid;
   grid-template-columns: 10vw 20vw 20vw 20vw 20vw 10vw;
-  grid-template-rows: 1fr 1fr;
-  margin-top: 10vh;
+  grid-template-rows: 0.5fr 1fr;
+  margin-top: 15vh !important;
   max-height: 90vh;
 }
 
@@ -28,7 +28,7 @@ div {
   grid-row-start: 2;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  margin-top: -10%;
+  /* margin-top: -15vh !important; */
 }
 
 .outfitCardContainer {
@@ -36,7 +36,7 @@ div {
   grid-row-start: 2;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  margin-top: -10%;
+  /* margin-top: -10%; */
 }
 
 .right {
@@ -87,7 +87,7 @@ div {
   height: 30vh;
   grid-column: 2;
   grid-row: 2;
-  margin-top: -15%;
+  margin-top: 2vh;
 }
 
 .modal {


### PR DESCRIPTION
## Description
fix spacing between related products headers and product cards

## How to test
manually. navigate to product id 48000

## Notes
seems to have been affected by other style changes. just fixed it appear as before in terms of spacing within widget

## Issue tracking
https://trello.com/c/XOWJ7hIt/188-fix-spacing